### PR TITLE
Make the indexing configurable

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -212,7 +212,13 @@ class AlgoliaIndex(object):
         result = None
         counts = 0
         batch = []
-        for instance in self.model.objects.all():
+
+        if getattr(self, 'get_queryset', None):
+            qs = self.get_queryset()
+        else:
+            qs = self.model.objects.all()
+
+        for instance in qs:
             if self.should_index:
                 attr = getattr(instance, self.should_index)
                 if not attr():


### PR DESCRIPTION
Following a common practice I opted to have a `get_queryset()` method that gives the possiblity to use a custom query.

It gives fine grain indexing possiblity as well as a performance optimisation as you can have a queryset with `select_related` (or `prefetch_related`)

Ex:
```python
    def get_queryset(self):
        """It is important to have the import here and not at the top of the file

        The reason is Django will do the import when initializing
        and will fail if there are non-lazy translations in the model
        """
        from myapp.models import MyModel
        return MyModel.objects.filter(
            date_accepted__gte=timezone.now() - timedelta(days=30),
        ).select_related('related_attribute')
```

refs #8 