### PR TITLE
Update multiple records with a QuerySet

### DIFF
--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -27,3 +27,4 @@ get_adapter = algolia_engine.get_adapter
 get_adapter_from_instance = algolia_engine.get_adapter_from_instance
 
 raw_search = algolia_engine.raw_search
+update_records = algolia_engine.update_records

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -220,8 +220,8 @@ class AlgoliaIndex(object):
 
         >>> from algoliasearch_django import update_records
         >>> qs = MyModel.objects.filter(myField=False)
-        >>> qs.update(myField=True)
         >>> update_records(MyModel, qs, myField=True)
+        >>> qs.update(myField=True)
         '''
         tmp = {}
         for key, value in kwargs:

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -224,7 +224,7 @@ class AlgoliaIndex(object):
         >>> qs.update(myField=True)
         '''
         tmp = {}
-        for key, value in kwargs:
+        for key, value in kwargs.items():
             name = self.__translate_fields.get(key, None)
             if name:
                 tmp[name] = value

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -230,8 +230,10 @@ class AlgoliaIndex(object):
                 tmp[name] = value
 
         batch = []
-        for instance in qs.only(self.custom_objectID):
-            tmp['objectID'] = self.objectID(instance)
+        objectsIDs = qs.only(self.custom_objectID).values_list(
+            self.custom_objectID, flat=True)
+        for elt in objectsIDs:
+            tmp['objectID'] = elt
             batch.append(dict(tmp))
 
             if len(batch) >= batch_size:

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -124,8 +124,8 @@ class AlgoliaEngine(object):
 
         >>> from algoliasearch_django import update_records
         >>> qs = MyModel.objects.filter(myField=False)
-        >>> qs.update(myField=True)
         >>> update_records(MyModel, qs, myField=True)
+        >>> qs.update(myField=True)
         '''
         adapter = self.get_adapter(model)
         adapter.update_records(qs, batch_size=batch_size, **kwargs)

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -114,6 +114,22 @@ class AlgoliaEngine(object):
         adapter = self.get_adapter_from_instance(obj)
         adapter.delete_record(obj)
 
+    def update_records(self, model, qs, batch_size=1000, **kwargs):
+        '''
+        Update multiple records of an index.
+
+        This method is optimized for speed. It takes a QuerySet and the same
+        arguments as QuerySet.update(). Optionnaly, you can specify the size
+        of the batch send to Algolia with batch_size (default to 1000).
+
+        >>> from algoliasearch_django import update_records
+        >>> qs = MyModel.objects.filter(myField=False)
+        >>> qs.update(myField=True)
+        >>> update_records(MyModel, qs, myField=True)
+        '''
+        adapter = self.get_adapter(model)
+        adapter.update_records(qs, batch_size=batch_size, **kwargs)
+
     def raw_search(self, model, query='', params={}):
         '''Return the raw JSON.'''
         adapter = self.get_adapter(model)


### PR DESCRIPTION
Here is my proposal for the limitation of `QuerySet.update()`. This method doesn't send signals so it's impossible for this module to update automatically the index on Algolia.

@redox proposed to subclass `QuerySet` and send signals for the `update()` method, however it will not work efficiently and would imply to subclass `models.Model` as well. I prefer a lighter approach.

Here is what the API looks like:

```python
>>> from algoliasearch_django import update_records
>>> qs = MyModel.objects.filter(myField=False)
>>> update_records(MyModel, qs, myField=True)
>>> # `update()` should be after `update_records` because here we filter and update the same field.
>>> qs.update(myField=True)
```

Instead of:

```python
>>> MyModel.objects.filter(myField=False).update(myField=True)
```

### What it does

First, I'm creating a raw object with the fields to update. Then, I use `only()` methods to get only the **custom_objectID** from the database. Finally I send a batch of update to Algolia API.

### Feedback

I would love to have some feedback/comments about it, cc @arnaudlimbourg and @kmaschta