### PR TITLE
Check that geo_field callable returns something valid

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -154,7 +154,9 @@ class AlgoliaIndex(object):
 
         if self.geo_field:
             loc = self.geo_field(instance)
-            tmp['_geoloc'] = {'lat': loc[0], 'lng': loc[1]}
+
+            if loc:
+                tmp['_geoloc'] = {'lat': loc[0], 'lng': loc[1]}
 
         if self.tags:
             attr = getattr(instance, self.tags)

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.2-adamghill'
+VERSION = '1.2.2'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.2'
+VERSION = '1.2.2-adamghill'

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -60,6 +60,15 @@ class IndexTestCase(TestCase):
         obj = index._build_object(self.instance)
         self.assertEqual(obj['_geoloc'], {'lat': 63.3, 'lng': -32.0})
 
+    def test_none_geo_fields(self):
+        class ExampleIndex(AlgoliaIndex):
+            geo_field = 'location'
+
+        Example.location = lambda x: None
+        index = ExampleIndex(Example, self.client)
+        obj = index._build_object(self.instance)
+        self.assertIsNone(obj.get('_geoloc'))
+
     def test_invalid_geo_fields(self):
         class ExampleIndex(AlgoliaIndex):
             geo_field = 'position'


### PR DESCRIPTION
I have some models that have a valid geo location, but others that don't. This will prevent those models without a valid location from preventing indexing.