### PR TITLE
Do not hardcode 'id' in AlgoliaIndex

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -60,17 +60,17 @@ class AlgoliaIndex(object):
                 raise AlgoliaIndexError(
                     '{} is not an attribute of {}.'.format(field, model))
 
-        # If no fields are specified, index all the fields of the model
-        if not self.fields:
-            self.fields = all_fields
-            self.fields.remove('id')
-
         # Check custom_objectID
         if self.custom_objectID:
             if not (hasattr(model, self.custom_objectID) or
                     (self.custom_objectID in all_fields)):
                 raise AlgoliaIndexError('{} is not an attribute of {}.'.format(
                     self.custom_objectID, model))
+
+        # If no fields are specified, index all the fields of the model
+        if not self.fields:
+            self.fields = all_fields
+            self.fields.remove(self.custom_objectID if self.custom_objectID else 'id')
 
         # Check tags
         if self.tags:

--- a/src/models.py
+++ b/src/models.py
@@ -70,7 +70,7 @@ class AlgoliaIndex(object):
         # If no fields are specified, index all the fields of the model
         if not self.fields:
             self.fields = all_fields
-            self.fields.remove(self.custom_objectID if self.custom_objectID else 'id')
+            self.fields.remove(self.custom_objectID if self.custom_objectID else model._meta.pk.name)
 
         # Check tags
         if self.tags:


### PR DESCRIPTION
We were not considering `custom_objectID` when removing 'id' from the
list of fields to index.