### PR TITLE
Reset method to leverage override_settings, solving #169 & #209

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,5 +259,22 @@ To run the tests, first find your Algolia application id and Admin API key (foun
 ALGOLIA_APPLICATION_ID={APPLICATION_ID} ALGOLIA_API_KEY={ADMIN_API_KEY} tox
 ```
 
+To override settings for some tests, use the [settings method](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.SimpleTestCase.settings):
+```python
+class OverrideSettingsTestCase(TestCase):
+    def setUp(self):
+        with self.settings(ALGOLIA={
+            'APPLICATION_ID': 'foo',
+            'API_KEY': 'bar',
+            'AUTO_INDEXING': False
+        }):
+            algolia_engine.reset(settings.ALGOLIA)
+
+    def tearDown(self):
+        algolia_engine.reset(settings.ALGOLIA)
+
+    def test_foo():
+        # ...
+```
 
 

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -166,6 +166,12 @@ class AlgoliaEngine(object):
         adapter = self.get_adapter(model)
         return adapter.reindex_all(batch_size)
 
+    def reset(self, settings=None):
+        """Reinitializes the Algolia engine and its client.
+        :param settings: settings to use instead of the default django.conf.settings.algolia
+        """
+        self.__init__(settings=settings if settings is not None else SETTINGS)
+
     # Signalling hooks.
 
     def __post_save_receiver(self, instance, **kwargs):
@@ -177,6 +183,7 @@ class AlgoliaEngine(object):
         """Signal handler for when a registered model has been deleted."""
         logger.debug('RECEIVE pre_delete FOR %s', instance.__class__)
         self.delete_record(instance)
+
 
 # Algolia engine
 algolia_engine = AlgoliaEngine()

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -22,7 +22,7 @@ class RegistrationError(AlgoliaEngineError):
 
 class AlgoliaEngine(object):
     def __init__(self, settings=SETTINGS):
-        """Initializes Algolia engine."""
+        """Initializes the Algolia engine."""
 
         try:
             app_id = settings['APPLICATION_ID']

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
+from algoliasearch_django import algolia_engine
 from algoliasearch_django import AlgoliaIndex
 from algoliasearch_django import AlgoliaEngine
 from algoliasearch_django.registration import AlgoliaEngineError
@@ -90,3 +91,19 @@ class EngineTestCase(TestCase):
 
         with self.assertRaises(RegistrationError):
             self.engine.unregister(Website)
+
+
+class OverrideSettingsTestCase(TestCase):
+    def setUp(self):
+        with self.settings(ALGOLIA={
+            'APPLICATION_ID': 'foo',
+            'API_KEY': 'bar',
+            'AUTO_INDEXING': False
+        }):
+            algolia_engine.reset(settings.ALGOLIA)
+
+    def tearDown(self):
+        algolia_engine.reset(settings.ALGOLIA)
+
+    def test_no_indexing(self):
+        self.assertFalse(algolia_engine.__dict__["_AlgoliaEngine__auto_indexing"], "AUTO_INDEXING should be disabled for this test.")


### PR DESCRIPTION
# Features
- Expose a reset method to reinitialize the AlgoliaEngine with optional new settings

# Tests
- Test demonstrating reinitialization after overriding `AUTO_INDEXING` at test time 

# Minor changes
- Improve docstrings