### PR TITLE
Add @property ObjectId support

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -125,7 +125,7 @@ class AlgoliaIndex(object):
                                                             self.fields)))
 
         # Check custom_objectID
-        if self.custom_objectID in chain(['pk'], all_model_fields) or hasattr(self, self.custom_objectID):
+        if self.custom_objectID in chain(['pk'], all_model_fields) or hasattr(model, self.custom_objectID):
             self.objectID = get_model_attr(self.custom_objectID)
         else:
             raise AlgoliaIndexError('{} is not a model field of {}'.format(

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -125,7 +125,7 @@ class AlgoliaIndex(object):
                                                             self.fields)))
 
         # Check custom_objectID
-        if self.custom_objectID in chain(['pk'], all_model_fields):
+        if self.custom_objectID in chain(['pk'], all_model_fields) or hasattr(self, self.custom_objectID):
             self.objectID = get_model_attr(self.custom_objectID)
         else:
             raise AlgoliaIndexError('{} is not a model field of {}'.format(

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,6 +11,10 @@ class User(models.Model):
     _lng = models.FloatField(default=0)
     _permissions = models.CharField(max_length=30, blank=True)
 
+    @property
+    def reverse_username(self):
+        return self.username[::-1]
+
     def location(self):
         return self._lat, self._lng
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -80,6 +80,14 @@ class IndexTestCase(TestCase):
         obj = index.get_raw_record(self.user)
         self.assertEqual(obj['objectID'], 'algolia')
 
+    def test_custom_objectID_property(self):
+        class UserIndex(AlgoliaIndex):
+            custom_objectID = 'reverse_username'
+
+        index = UserIndex(User, self.client, settings.ALGOLIA)
+        obj = index.get_raw_record(self.user)
+        self.assertEqual(obj['objectID'], 'ailogla')
+
     def test_invalid_custom_objectID(self):
         class UserIndex(AlgoliaIndex):
             custom_objectID = 'uid'


### PR DESCRIPTION
Reopening #214 on a branch we control to add a test and fix the implementation.

>This will allow for use of `@property` fields to be used for the `objectID`
