### PR TITLE
Fix reindex_all() and save_record() when should_index is not callable

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -278,13 +278,12 @@ class AlgoliaIndex(object):
         For more information about partial_update_object:
         https://github.com/algolia/algoliasearch-client-python#update-an-existing-object-in-the-index
         """
-        if self.should_index:
-            if not self.should_index(instance):
-                # Should not index, but since we don't now the state of the
-                # instance, we need to send a DELETE request to ensure that if
-                # the instance was previously indexed, it will be removed.
-                self.delete_record(instance)
-                return
+        if not self._should_index(instance):
+            # Should not index, but since we don't now the state of the
+            # instance, we need to send a DELETE request to ensure that if
+            # the instance was previously indexed, it will be removed.
+            self.delete_record(instance)
+            return
 
         try:
             if update_fields:
@@ -424,9 +423,8 @@ class AlgoliaIndex(object):
                 qs = self.model.objects.all()
 
             for instance in qs:
-                if self.should_index:
-                    if not self.should_index(instance):
-                        continue  # should not index
+                if not self._should_index(instance):
+                    continue  # should not index
 
                 batch.append(self.get_raw_record(instance))
                 if len(batch) >= batch_size:

--- a/tests/models.py
+++ b/tests/models.py
@@ -25,6 +25,7 @@ class User(models.Model):
 class Website(models.Model):
     name = models.CharField(max_length=100)
     url = models.URLField()
+    is_online = models.BooleanField(default=False)
 
 
 class Example(models.Model):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -72,6 +72,25 @@ class IndexTestCase(TestCase):
         index = WebsiteIndex(Website, self.client, settings.ALGOLIA)
         index.reindex_all()
 
+    def test_reindex_with_should_index_boolean(self):
+        Website.objects.create(
+            name='Algolia',
+            url='https://algolia.com',
+            is_online=True
+        )
+        index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+        class WebsiteIndex(AlgoliaIndex):
+            settings = {
+                'replicas': [
+                    index.index_name + '_name_asc',
+                    index.index_name + '_name_desc'
+                ]
+            }
+            should_index = 'is_online'
+
+        index = WebsiteIndex(Website, self.client, settings.ALGOLIA)
+        index.reindex_all()
+
     def test_custom_objectID(self):
         class UserIndex(AlgoliaIndex):
             custom_objectID = 'username'
@@ -382,3 +401,22 @@ class IndexTestCase(TestCase):
         index = ExampleIndex(Example, self.client, settings.ALGOLIA)
         with self.assertRaises(AlgoliaIndexError, msg="We should raise when the should_index property is not boolean"):
             index._should_index(self.example)
+
+    def test_save_record_should_index_boolean(self):
+        website = Website.objects.create(
+            name='Algolia',
+            url='https://algolia.com',
+            is_online=True
+        )
+        index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+        class WebsiteIndex(AlgoliaIndex):
+            settings = {
+                'replicas': [
+                    index.index_name + '_name_asc',
+                    index.index_name + '_name_desc'
+                ]
+            }
+            should_index = 'is_online'
+
+        index = WebsiteIndex(Website, self.client, settings.ALGOLIA)
+        index.save_record(website)


### PR DESCRIPTION
Hello there,

When `should_index` is not callable, both `reindex_all()` and `save_record()` are broken. Here is an attempt to fix it. I've used test-driven development to avoid any regression,

Cheers 👍