### PR TITLE
Migrate release to twine

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 
-HANGELOG
+CHANGELOG
+2017-11-02 1.5.1
+  * [FIX] Fix reindex_all() and save_record() when should_index is not callable
+
 2017-05-21 1.5.0
   * [FEAT] Allow properties as custom_objectID
 

--- a/algoliasearch_django/version.py
+++ b/algoliasearch_django/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.0'
+VERSION = '1.5.1'

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+rm -f dist/* # Remove eventual previous versions
+python setup.py sdist bdist_wheel # Create Source Distribution and Universal Wheel
+twine upload dist/* # Upload to PyPI
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 django>=1.7
 algoliasearch
-tox
-wheel
+# dev dependencies
 pypandoc
+wheel
+tox
+twine


### PR DESCRIPTION
The current release process stopped working as it was still targeting the legacy pypi.python.org.

I followed the recommandations in the [Migrating to Pypi.org guide](https://packaging.python.org/guides/migrating-to-pypi-org/?highlight=upgrading%20pypi), using `twine` instead of the [unsecure](https://pypi.python.org/pypi/twine#why-should-i-use-this) `setup.py upload` command.