### PR TITLE
Fix tags when using callable

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -217,10 +217,9 @@ class AlgoliaIndex(object):
 
             if self.tags:
                 if callable(self.tags):
-                    self.tags = self.tags(instance)
-                if not isinstance(self.tags, list):
-                    self.tags = list(self.tags)
-                tmp['_tags'] = self.tags
+                    tmp['_tags'] = self.tags(instance)
+                if not isinstance(tmp['_tags'], list):
+                    tmp['_tags'] = list(tmp['_tags'])
 
         logger.debug('BUILD %s FROM %s', tmp['objectID'], self.model)
         return tmp

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -15,6 +15,18 @@ class IndexTestCase(TestCase):
                          bio='Milliseconds matter', followers_count=42001,
                          following_count=42, _lat=123, _lng=-42.24,
                          _permissions='read,write,admin')
+
+        self.contributor = User(
+            name='Contributor',
+            username="contributor",
+            bio='Contributions matter',
+            followers_count=7,
+            following_count=5,
+            _lat=52.0705,
+            _lng=-4.3007,
+            _permissions='contribute,follow'
+        )
+
         self.example = Example(uid=4,
                                name='SuperK',
                                address='Finland',
@@ -163,8 +175,13 @@ class IndexTestCase(TestCase):
             tags = 'permissions'
 
         index = UserIndex(User, self.client, settings.ALGOLIA)
+
+        # Test the users' tag individually
         obj = index.get_raw_record(self.user)
         self.assertListEqual(obj['_tags'], ['read', 'write', 'admin'])
+
+        obj = index.get_raw_record(self.contributor)
+        self.assertListEqual(obj['_tags'], ['contribute', 'follow'])
 
     def test_invalid_tags(self):
         class UserIndex(AlgoliaIndex):


### PR DESCRIPTION
If a callable is used, it should be called for each and every instance as the result is supposed to vary between class instances.

An Algolia index has a `tags` class attribute (common to all instances). It should not be redefined in the index model code through an instance (see ``models.AlgoliaIndex.get_raw_record``)
because modifying a class attribute will have an impact on all instances (this is the difference between defining attributes in the class body and in the dunder __init__ method).

See issue for more context: https://github.com/algolia/algoliasearch-django/issues/228