### PR TITLE
Fix #238: reindex deletes settings (again)

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -59,7 +59,7 @@ class AlgoliaIndex(object):
     index_name = None
 
     # Use to specify the settings of the index.
-    settings = {}
+    settings = None
 
     # Used to specify if the instance should be indexed.
     # The attribute should be either:
@@ -79,6 +79,9 @@ class AlgoliaIndex(object):
         self.__client = client
         self.__named_fields = {}
         self.__translate_fields = {}
+
+        if self.settings is None:  # Only set settings if the actual index class does not define some
+            self.settings = {}
 
         try:
             all_model_fields = [f.name for f in model._meta.get_fields() if not f.is_relation]

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -420,6 +420,8 @@ class AlgoliaIndex(object):
             if not self.settings:
                 self.settings = self.get_settings()
                 logger.debug('Got settings for index %s: %s', self.index_name, self.settings)
+            else:
+                logger.debug("index %s already has settings: %s", self.index_name, self.settings)
         except AlgoliaException as e:
             if any("Index does not exist" in arg for arg in e.args):
                 pass  # Expected, let's clear and recreate from scratch

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -138,6 +138,8 @@ class IndexTestCase(TestCase):
                          "An index whose model has no settings should keep its settings after reindex")
 
     def test_reindex_with_settings(self):
+        import uuid
+        id = str(uuid.uuid4())
         self.maxDiff = None
         index_settings = {'searchableAttributes': ['name', 'email', 'company', 'city', 'county', 'account_names',
                                                    'unordered(address)', 'state', 'zip_code', 'phone', 'fax',
@@ -156,7 +158,8 @@ class IndexTestCase(TestCase):
                               'exact',
                               'custom'
                           ],
-                          'replicas': ['WebsiteIndexReplica_name_asc', 'WebsiteIndexReplica_name_desc'],
+                          'replicas': ['WebsiteIndexReplica_' + id + '_name_asc',
+                                       'WebsiteIndexReplica_' + id + '_name_desc'],
                           'highlightPostTag': '</mark>', 'hitsPerPage': 15}
 
         # Given an existing index defined with settings

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -41,7 +41,6 @@ class IndexTestCase(TestCase):
             {'lat': 22.3, 'lng': 10.0},
         ]
 
-
     def test_default_index_name(self):
         index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
         regex = r'^test_Website_django(_travis-\d+.\d+)?$'
@@ -165,9 +164,10 @@ class IndexTestCase(TestCase):
         :return: the new settings
         """
         # When reindexing with settings on the instance
-        index.settings = {'hitsPerPage': 42}
+        old_hpp = index.settings['hitsPerPage'] if 'hitsPerPage' in index.settings else None
+        index.settings['hitsPerPage'] = 42
         index.reindex_all()
-        index.settings = None
+        index.settings['hitsPerPage'] = old_hpp
         time.sleep(10)  # FIXME: Refactor reindex_all to return taskID
         index_settings = index.get_settings()
         # Expect the instance's settings to be applied at reindex


### PR DESCRIPTION
From [this comment](https://github.com/algolia/algoliasearch-django/issues/238#issuecomment-363117562), `v1.5.4` did not fix the issue.

For now this PR contains two tests that should assert expected behavior:
- `test_reindex_no_settings` asserts that _without explicit settings definition, existing settings are kept across reindex_
- `test_reindex_with_settings` asserts that _with explicit settings definition, these settings are applied over reindex_

The next step is to get more info on the failing use case to compare with these tests.