### PR TITLE
Fix/default log handler

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 
 CHANGELOG
+2018-02-14 1.5.5
+  * [FIX] Settings no more shared across AlgoliaIndex instances
+  * [FIX] Save rules and synonyms over reindex
+
 2018-01-16 1.5.4
   * Shallow release to solve 1.5.3 release issue
 

--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -30,3 +30,14 @@ update_records = algolia_engine.update_records
 raw_search = algolia_engine.raw_search
 clear_index = algolia_engine.clear_index
 reindex_all = algolia_engine.reindex_all
+
+# Default log handler
+import logging
+
+
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
+logging.getLogger(__name__.split('.')[0]).addHandler(NullHandler())

--- a/algoliasearch_django/version.py
+++ b/algoliasearch_django/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.4'
+VERSION = '1.5.5'

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -31,7 +31,7 @@ class SignalTestCase(TestCase):
         Website.objects.create(name='Google', url='https://www.google.com')
         Website.objects.create(name='Facebook', url='https://www.facebook.com')
 
-        time.sleep(5)
+        time.sleep(10)  # FIXME: Expose last task's ID so we can waitTask instead of sleeping
         self.assertEqual(raw_search(Website)['nbHits'], 3)
 
     def test_delete_signal(self):
@@ -42,7 +42,7 @@ class SignalTestCase(TestCase):
         Website.objects.get(name='Algolia').delete()
         Website.objects.get(name='Facebook').delete()
 
-        time.sleep(5)
+        time.sleep(10)
         result = raw_search(Website)
         self.assertEqual(result['nbHits'], 1)
         self.assertEqual(result['hits'][0]['name'], 'Google')
@@ -58,7 +58,7 @@ class SignalTestCase(TestCase):
         update_records(Website, qs, url='https://facebook.com')
         qs.update(url='https://facebook.com')
 
-        time.sleep(5)
+        time.sleep(10)
         result = raw_search(Website, 'Facebook')
         self.assertEqual(result['nbHits'], qs.count())
         for res, url in zip(result['hits'], qs.values_list('url', flat=True)):


### PR DESCRIPTION
Following a [Support ticket](https://secure.helpscout.net/conversation/549738419/56124/?folderId=1106372):
> When we are attempting to reindex our account, we are receiving this response (using Algolia' django project) 
> `No handlers could be found for logger "algoliasearch_django.models"`

Indeed, we didn't follow the recommended way to [Configure logging for a library](https://docs.python.org/3.1/library/logging.html#configuring-logging-for-a-library):
> In addition to documenting how a library uses logging, a good way to configure library logging so that it does not cause a spurious message is to add a handler which does nothing.

This PR implements such a NullHandler. I'm not using the [`NullHandler`](https://docs.python.org/3.1/library/logging.html#logging.NullHandler) class as it's only available with `python > 3.1`.