### PR TITLE
Add Python version and django version to UserAgent

### DIFF
--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -8,6 +8,8 @@ from algoliasearch import algoliasearch
 from .models import AlgoliaIndex
 from .settings import SETTINGS
 from .version import VERSION
+from algoliasearch.version import VERSION as CLIENT_VERSION
+from platform import python_version
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,8 @@ class AlgoliaEngine(object):
         self.__registered_models = {}
         self.client = algoliasearch.Client(app_id, api_key)
         self.client.set_extra_header('User-Agent',
-                                     'Algolia for Django {}'.format(VERSION))
+                                     'Algolia for Python (%s); Python (%s); Algolia for Django (%s)'
+                                     % (CLIENT_VERSION, python_version(), VERSION))
 
     def is_registered(self, model):
         """Checks whether the given models is registered with Algolia engine"""


### PR DESCRIPTION
We're adding the language version to all client.

Because in python we rely on `setExtraHeader`, the client version was lost, I'm adding it as well.