### PR TITLE
Test refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ wheel
 tox
 twine
 factory_boy
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pypandoc
 wheel
 tox
 twine
+factory_boy

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,37 @@
+import factory
+
+from .models import (
+    Example,
+    User,
+    Website
+)
+
+
+class ExampleFactory(factory.django.DjangoModelFactory):
+    uid = factory.Sequence(lambda n: n)
+    name = factory.Sequence(lambda n: 'Example name-{}'.format(n))
+    address = factory.Sequence(lambda n: 'Example address-{}'.format(n))
+    lat = factory.Faker('latitude')
+    lng = factory.Faker('longitude')
+
+    class Meta:
+        model = Example
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    name = factory.Sequence(lambda n: 'User name-{}'.format(n))
+    username = factory.Sequence(lambda n: 'User username-{}'.format(n))
+
+    _lat = factory.Faker('latitude')
+    _lng = factory.Faker('longitude')
+
+    class Meta:
+        model = User
+
+
+class WebsiteFactory(factory.django.DjangoModelFactory):
+    name = factory.Sequence(lambda n: 'Website name-{}'.format(n))
+    url = factory.Faker('url')
+
+    class Meta:
+        model = Website

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ skip_missing_interpreters = True
 [testenv]
 deps =
     six
+    factory_boy
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ skip_missing_interpreters = True
 [testenv]
 deps =
     six
+    mock
     factory_boy
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
Some tests refactoring:

- [x] Use [Factory boy](http://factoryboy.readthedocs.io/en/latest/), easier to maintain / write / read.
- [x] Use [mock](https://docs.python.org/dev/library/unittest.mock.html), faster tests.

Next step will be to implement and use the `waitTask` from the python client, for the tests that really need to wait for the response from Algolia.