### PR TITLE
Drop support of Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
     env: TOXENV=py27-django18
   - python: 2.7
     env: TOXENV=py27-django19
-  - python: 3.3
-    env: TOXENV=py33-django17
-  - python: 3.3
-    env: TOXENV=py33-django18
   - python: 3.4
     env: TOXENV=py34-django17
   - python: 3.4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package lets you easily integrate the Algolia Search API to your [Django](h
 
 You might be interested in this sample Django application providing a typeahead.js based auto-completion and Google-like instant search: [algoliasearch-django-example](https://github.com/algolia/algoliasearch-django-example)
 
-Compatible with **Python 2.7**, **Python 3.3+** and **Django 1.7+**
+Compatible with **Python 2.7**, **Python 3.4+** and **Django 1.7+**
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,py33,py34}-django17
-    {py27,py33,py34,py35,py36}-django18
+    {py27,py34}-django17
+    {py27,py34,py35,py36}-django18
     {py27,py34,py35,py36}-django19
     coverage
 skip_missing_interpreters = True


### PR DESCRIPTION
Despite the name of this PR, we were not compatible with python 3.3, since the [algoliasearch](https://github.com/algolia/algoliasearch-client-python) python package is not (dependency on the `requests` package).

So I just updated the readme and removed the tests concerning this version (who is not supported anymore according to the [pep-0398](https://www.python.org/dev/peps/pep-0398/#id21)