### PR TITLE
fix(tests) Add tox envs for Django 1.10,1.11,2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,42 @@ matrix:
     env: TOXENV=py27-django18
   - python: 2.7
     env: TOXENV=py27-django19
+  - python: 2.7
+    env: TOXENV=py27-django110
+  - python: 2.7
+    env: TOXENV=py27-django111
   - python: 3.4
     env: TOXENV=py34-django17
   - python: 3.4
     env: TOXENV=py34-django18
   - python: 3.4
     env: TOXENV=py34-django19
+  - python: 3.4
+    env: TOXENV=py34-django110
+  - python: 3.4
+    env: TOXENV=py34-django111
+  - python: 3.4
+    env: TOXENV=py34-django20
   - python: 3.5
     env: TOXENV=py35-django18
   - python: 3.5
     env: TOXENV=py35-django19
+  - python: 3.5
+    env: TOXENV=py35-django110
+  - python: 3.5
+    env: TOXENV=py35-django111
+  - python: 3.5
+    env: TOXENV=py35-django20
   - python: 3.6
     env: TOXENV=py36-django18
   - python: 3.6
     env: TOXENV=py36-django19
+  - python: 3.6
+    env: TOXENV=py36-django110
+  - python: 3.6
+    env: TOXENV=py36-django111
+  - python: 3.6
+    env: TOXENV=py36-django20
 env:
   global:
   - secure: BvefwB7dAyxeVeIwaDoklOwE04DkuP4xqj18awneFYJdln2qWUB/AcchVGrp6Toi1XnL+4e/CkSRbj/XLr3FBceARknfgzT3zp7BQyJLREAXFXV75dcCtcN9Jxh4IMpNlLTcZcB8OvU+edrRulmsOR0hXIie8rLg3pt+2LfGxhVzaUBq6F9vv+Db7tdZ+DNnciA+geJQZ+ThtxxUzVcNqCgTvQSrPYMGx07ScEG6MuEakHopEVuTE3n7hiOZW/17sS4uBfj+JwL3RX1gg/lnobbicYxBJ+WzuIP2cpVGLDJDwnclqlAezPMEG0AymeOrM9/5fYRkyawOyeaJZFmcd4cqnKurG/lDmidABzB3LXYWnAYVMOsQ5R9JqRRa+AVHt8u1wJZu4VXMoI7AtLHaMCVBO0iAGkH7dD41oy/aMzN63bIp+ANo7seIouxRfCX62H5+1unUbYYExsKvUhwb7uSLLq67QcbkudklIpb/xsNkueqFgJ9APBH3/K7MYjRjPrCA8pjOgnWXyzJRty+fZctrJZTbWg9ubky7t/48enDmFzDOgMjnEtkKAXYO7lHDEsA2HceLtYx08VI9Hfry579AhdqZSRaXZejSN8ZUIOHJLXT+2Md35IuySTpqkQiEjDYWwhLooEFvrirVB+3YCw6Sw6kAoT7P5FS2hOOZtKw=

--- a/tests/models.py
+++ b/tests/models.py
@@ -70,5 +70,8 @@ class Example(models.Model):
 
 
 class BlogPost(models.Model):
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE
+    )
     text = models.TextField(default="")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -89,8 +89,11 @@ class CommandsTestCase(TestCase):
             self.assertRegexpMatches(result, regex)
 
     def test_clearindex_with_args(self):
-        call_command('algolia_clearindex', stdout=self.out,
-                     model=['Website'], batchsize=3)
+        call_command(
+            'algolia_clearindex',
+            stdout=self.out,
+            model=['Website']
+        )
         result = self.out.getvalue()
 
         regex = r'Website'

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist =
     {py27,py34}-django17
     {py27,py34,py35,py36}-django18
     {py27,py34,py35,py36}-django19
+    {py27,py34,py35,py36}-django110
+    {py27,py34,py35,py36}-django111
+    {py34,py35,py36}-django20
     coverage
 skip_missing_interpreters = True
 
@@ -11,6 +14,9 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
 passenv =
     ALGOLIA*
     TRAVIS*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | None
| Need Doc update   | no


## What was changed

- [x] Updated the `tox.ini` and `travis.yml` files, adding the env for the `1.10`, `1.11` and `2.0` Django versions.
- [x] Fixed two tests that was failing on Django `2.0` (not impacting the previous versions).

## Why it was changed

So we are sure we are compatibles with the version stated in the README :)