### PR TITLE
fix(models) Refactor reindex_all to allow waiting for tasks

### DIFF
--- a/algoliasearch_django/management/commands/algolia_reindex.py
+++ b/algoliasearch_django/management/commands/algolia_reindex.py
@@ -25,5 +25,5 @@ class Command(BaseCommand):
                                                    options['model']):
                 continue
 
-            counts = reindex_all(model, batch_size=batch_size)
+            counts, _ = reindex_all(model, batch_size=batch_size)
             self.stdout.write('\t* {} --> {}'.format(model.__name__, counts))

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+
+class AlgoliaSearchDjangoTestCase(TestCase):
+    """A test case providing shortcuts methods"""
+
+    @staticmethod
+    def wait_for_tasks(index, *task_ids):
+        """Wait all the provided task ids on the given index
+
+        :param index: The index on the tasks were created
+        :type index: AlgoliaIndex
+        :param task_ids: A list of task that we want to wait for
+        :type task_ids: list
+
+        """
+
+        for task_id in task_ids:
+            index.wait_task(task_id)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | #249
| Need Doc update   | no


## What was changed

- The `reindex_all` method was refactored, returning now a `tuple` containing the number of objects indexed (`counts`) and a list of `taskID` to wait for if needed.

- The tests for this methods were updated, matching the new method signature, using `wait_task` on the returned `task_ids`, instead of `sleep()`.

- During the refactoring, I took the liberty to "flatten" the `wait_task` (way too many branches to be clear).

## Why it was changed

As stated in #249, the `sleep(10)` in multiple places in the tests were making the tests slower. Refactoring the `reindex_all` allow to return a list of `taskID` to wait for, thus making the tests faster.