### PR TITLE
chore: Bump version to 1.6.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 
 CHANGELOG
+
+2018-05-30 1.6.0
+  * [FEAT] Auto-discover the index.py files
+
 2018-02-14 1.5.5
   * [FIX] Settings no more shared across AlgoliaIndex instances
   * [FIX] Save rules and synonyms over reindex

--- a/algoliasearch_django/version.py
+++ b/algoliasearch_django/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.6'
+VERSION = '1.6.0'


### PR DESCRIPTION
Bump the version to 1.6.0:

* [FEAT] Auto-discover the index.py files