### PR TITLE
fix(Index) Make the temp index name respect the suffix and prefix

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -164,13 +164,23 @@ class AlgoliaIndex(object):
         if not self.index_name:
             self.index_name = model.__name__
 
+        tmp_index_name = '{index_name}_tmp'.format(index_name=self.index_name)
+
         if 'INDEX_PREFIX' in settings:
             self.index_name = settings['INDEX_PREFIX'] + '_' + self.index_name
+            tmp_index_name = '{index_prefix}_{tmp_index_name}'.format(
+                tmp_index_name=tmp_index_name,
+                index_prefix=settings['INDEX_PREFIX']
+            )
         if 'INDEX_SUFFIX' in settings:
             self.index_name += '_' + settings['INDEX_SUFFIX']
+            tmp_index_name = '{tmp_index_name}_{index_suffix}'.format(
+                tmp_index_name=tmp_index_name,
+                index_suffix=settings['INDEX_SUFFIX']
+            )
 
         self.__index = client.init_index(self.index_name)
-        self.__tmp_index = client.init_index(self.index_name + '_tmp')
+        self.__tmp_index = client.init_index(tmp_index_name)
 
     @staticmethod
     def _validate_geolocation(geolocation):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -82,6 +82,54 @@ class IndexTestCase(TestCase):
             except AttributeError:
                 self.assertRegexpMatches(self.index.index_name, regex)
 
+    def test_tmp_index_name(self):
+        """Test that the temporary index name should respect suffix and prefix settings"""
+
+        algolia_settings = dict(settings.ALGOLIA)
+
+        # With no suffix nor prefix
+        del algolia_settings['INDEX_PREFIX']
+        del algolia_settings['INDEX_SUFFIX']
+
+        with self.settings(ALGOLIA=algolia_settings):
+            self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+            self.assertEqual(
+                self.index._AlgoliaIndex__tmp_index.index_name,
+                'Website_tmp'
+            )
+
+        # With only a prefix
+        algolia_settings['INDEX_PREFIX'] = 'prefix'
+
+        with self.settings(ALGOLIA=algolia_settings):
+            self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+            self.assertEqual(
+                self.index._AlgoliaIndex__tmp_index.index_name,
+                'prefix_Website_tmp'
+            )
+
+        # With only a suffix
+        del algolia_settings['INDEX_PREFIX']
+        algolia_settings['INDEX_SUFFIX'] = 'suffix'
+
+        with self.settings(ALGOLIA=algolia_settings):
+            self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+            self.assertEqual(
+                self.index._AlgoliaIndex__tmp_index.index_name,
+                'Website_tmp_suffix'
+            )
+
+        # With a prefix and a suffix
+        algolia_settings['INDEX_PREFIX'] = 'prefix'
+        algolia_settings['INDEX_SUFFIX'] = 'suffix'
+
+        with self.settings(ALGOLIA=algolia_settings):
+            self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
+            self.assertEqual(
+                self.index._AlgoliaIndex__tmp_index.index_name,
+                'prefix_Website_tmp_suffix'
+            )
+
     def test_reindex_with_replicas(self):
         self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #267 
| Need Doc update   | no


## Describe your change

The temporary index name is now updated accordingly to the `PREFIX` and `SUFFIX` settings, like the following:

`{prefix}_{index_name}_tmp_{suffix}`

## What problem is this fixing?

See #267 
