### PR TITLE
Fixes non specified version of algoliasearch in requirements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 
 CHANGELOG
 
+Unreleased
+  * [FIX] Fixes non specified version of algoliasearch in requirements (#281)
+
 2018-08-27 1.7.0
   * [FEAT] Context Decorator to temporarily disable the auto-indexing (#266)
   * [FIX] Make the temp index name respect the suffix and prefix (#268)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.7
-algoliasearch
+algoliasearch>=1.0,<2.0
 # dev dependencies
 pypandoc
 wheel

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     license='MIT License',
     packages=find_packages(exclude=['tests']),
-    install_requires=['django>=1.7', 'algoliasearch'],
+    install_requires=['django>=1.7', 'algoliasearch>=1.0,<2.0'],
     description='Algolia Search integration for Django',
     long_description=README,
     author='Algolia Team',


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Related Issue     | Fix #280 
| Need Doc update   | no

## What problem is this fixing?

Since the version of `algoliasearch` is not specified on the requirements. When people perform `pip install algoliasearch-django`, pip will try to install the beta version of our client.

This pull request forces the installation of the `v1` of the `algoliasearch`.
