### PR TITLE
fix: prevent deprecation warning by removing deprecated call to set_extra_header

### DIFF
--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -39,9 +39,12 @@ class AlgoliaEngine(object):
 
         self.__registered_models = {}
         self.client = algoliasearch.Client(app_id, api_key)
-        self.client.set_extra_header('User-Agent',
-                                     'Algolia for Python (%s); Python (%s); Algolia for Django (%s); Django (%s)'
-                                     % (CLIENT_VERSION, python_version(), VERSION, django_version))
+        self.client.set_extra_headers(
+            **{
+                "User-Agent": "Algolia for Python (%s); Python (%s); Algolia for Django (%s); Django (%s)"
+                % (CLIENT_VERSION, python_version(), VERSION, django_version)
+            }
+        )
 
     def is_registered(self, model):
         """Checks whether the given models is registered with Algolia engine"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.7
-algoliasearch>=1.0,<2.0
+algoliasearch>=1.6,<2.0
 # dev dependencies
 pypandoc
 wheel

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -262,7 +262,13 @@ class IndexTestCase(TestCase):
         time.sleep(10)  # FIXME: Refactor reindex_all to return taskID
 
         # Expect the rules to be kept across reindex
+        def remove_metadata(rule):
+            copy = dict(rule)
+            del copy["_metadata"]
+            return copy
+
         rules = [r for r in underlying_index.iter_rules()]
+        rules = list(map(remove_metadata, rules))
         self.assertEqual(len(rules), 1, "There should only be one rule")
         self.assertIn(rule, rules, "The existing rule should be kept over reindex")
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     six
     mock
     factory_boy
+    py{27,34}: Faker>=1.0,<2.0
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
**Description:**

A user reported an issue with a warning coming from our Django
codebase due to a deprecated call to our Python client
`client.set_extra_header`. This commit replaces this deprecated call
(since version `1.6.0` of our Python client, see commit
https://github.com/algolia/algoliasearch-client-python/commit/e6efb38ecd4c9f85df319c7eab5c317c68eab4da
for more details) with `client.set_extra_headers` instead. It also
ensures the requirements for our Python client is at least at version `1.6.0`.


**Testing plan:**

Running the regular test suite without any issue.