### PR TITLE
chore(test): test against django 2.2 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ matrix:
     env: TOXENV=py36-django111
   - python: 3.6
     env: TOXENV=py36-django20
+  - python: 3.6
+    env: TOXENV=py36-django22LTS
+  - python: 3.6
+    env: TOXENV=py36-django31
 env:
   global:
   - secure: BvefwB7dAyxeVeIwaDoklOwE04DkuP4xqj18awneFYJdln2qWUB/AcchVGrp6Toi1XnL+4e/CkSRbj/XLr3FBceARknfgzT3zp7BQyJLREAXFXV75dcCtcN9Jxh4IMpNlLTcZcB8OvU+edrRulmsOR0hXIie8rLg3pt+2LfGxhVzaUBq6F9vv+Db7tdZ+DNnciA+geJQZ+ThtxxUzVcNqCgTvQSrPYMGx07ScEG6MuEakHopEVuTE3n7hiOZW/17sS4uBfj+JwL3RX1gg/lnobbicYxBJ+WzuIP2cpVGLDJDwnclqlAezPMEG0AymeOrM9/5fYRkyawOyeaJZFmcd4cqnKurG/lDmidABzB3LXYWnAYVMOsQ5R9JqRRa+AVHt8u1wJZu4VXMoI7AtLHaMCVBO0iAGkH7dD41oy/aMzN63bIp+ANo7seIouxRfCX62H5+1unUbYYExsKvUhwb7uSLLq67QcbkudklIpb/xsNkueqFgJ9APBH3/K7MYjRjPrCA8pjOgnWXyzJRty+fZctrJZTbWg9ubky7t/48enDmFzDOgMjnEtkKAXYO7lHDEsA2HceLtYx08VI9Hfry579AhdqZSRaXZejSN8ZUIOHJLXT+2Md35IuySTpqkQiEjDYWwhLooEFvrirVB+3YCw6Sw6kAoT7P5FS2hOOZtKw=

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -30,15 +30,34 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 )
+
+MIDDLEWARE = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
 
 ROOT_URLCONF = 'tests.urls'
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,18 +29,15 @@ INSTALLED_APPS = (
     'tests'
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-)
-
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 ]
 
 TEMPLATES = [

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 from django.core.management import call_command
 
 from algoliasearch_django import algolia_engine

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,10 @@ envlist =
     {py27,py34,py35,py36}-django110
     {py27,py34,py35,py36}-django111
     {py34,py35,py36}-django20
+    {py34,py35,py36}-django21
+    {py34,py35,py36}-django22LTS
+    {py34,py35,py36}-django30
+    {py34,py35,py36}-django31
     coverage
 skip_missing_interpreters = True
 
@@ -21,6 +25,10 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22LTS: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 passenv =
     ALGOLIA*
     TRAVIS*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes 
| BC breaks?        | no     
| Related Issue     | Fix https://github.com/algolia/algoliasearch-django/issues/287
| Need Doc update   | yes


## Describe your change

This PR:
- adds tests for django 2.2LTS and django 3.x
- introduces the migration changes required to move from 1.x to 2.0, namely introduction of API: `MIDDLEWARES` and `Templates`. 

See file diff for line by line comments on changes. 

## What problem is this fixing?

This confirms our Django integration test suite runs on 2.2LTS and current latest version: 3.x.


## Side note
In a future PR, I think it would be sensible to deperecate all other versions than thoses currently supported.
Currently supported versions are **2.2 (LTS), 3.0 and 3.1**. This would make the test suite much lighter and faster to run.
