### PR TITLE
chore(deps): update algoliasearch to latest major

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.7
-algoliasearch>=1.6,<2.0
+algoliasearch>=2.0,<3.0
 # dev dependencies
 pypandoc
 wheel


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes   
| BC breaks?        | no     
| Related Issue     | Fix https://github.com/algolia/algoliasearch-django/issues/298
| Need Doc update   | no


## Describe your change

This updates the python client used to the latest major (>= 2.0).
Let's run on Travis the tests and see if anything breaks 😄 

## What problem is this fixing?

It's not easy to use two different versions of the same library in python.
Using the Django integration got you stuck with the older version of the client. 
