### PR TITLE
chore(deps): update algoliasearch to latest major

### DIFF
--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -30,7 +30,8 @@ save_record = algolia_engine.save_record
 delete_record = algolia_engine.delete_record
 update_records = algolia_engine.update_records
 raw_search = algolia_engine.raw_search
-clear_index = algolia_engine.clear_index
+clear_index = algolia_engine.clear_index # TODO: deprecate
+clear_objects = algolia_engine.clear_objects
 reindex_all = algolia_engine.reindex_all
 
 # Default log handler

--- a/algoliasearch_django/management/commands/algolia_clearindex.py
+++ b/algoliasearch_django/management/commands/algolia_clearindex.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from algoliasearch_django import get_registered_model
-from algoliasearch_django import clear_index
+from algoliasearch_django import clear_objects
 
 
 class Command(BaseCommand):
@@ -18,5 +18,5 @@ class Command(BaseCommand):
                                                    options['model']):
                 continue
 
-            clear_index(model)
+            clear_objects(model)
             self.stdout.write('\t* {}'.format(model.__name__))

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -6,7 +6,7 @@ from itertools import chain
 import logging
 
 import sys
-from algoliasearch.helpers import AlgoliaException
+from algoliasearch.exceptions import AlgoliaException
 from django.db.models.query_utils import DeferredAttribute
 
 from .settings import DEBUG
@@ -179,8 +179,10 @@ class AlgoliaIndex(object):
                 index_suffix=settings['INDEX_SUFFIX']
             )
 
+        self.tmp_index_name = tmp_index_name
+
         self.__index = client.init_index(self.index_name)
-        self.__tmp_index = client.init_index(tmp_index_name)
+        self.__tmp_index = client.init_index(self.tmp_index_name)
 
     @staticmethod
     def _validate_geolocation(geolocation):
@@ -400,16 +402,20 @@ class AlgoliaIndex(object):
                 logger.warning('SETTINGS NOT APPLIED ON %s: %s',
                                self.model, e)
 
-    def clear_index(self):
-        """Clears the index."""
+    def clear_objects(self):
+        """Clears all objects of an index."""
         try:
-            self.__index.clear_index()
+            self.__index.clear_objects()
             logger.info('CLEAR INDEX %s', self.index_name)
         except AlgoliaException as e:
             if DEBUG:
                 raise e
             else:
                 logger.warning('%s NOT CLEARED: %s', self.model, e)
+
+    def clear_index(self):
+        # TODO: add deprecated warning
+        self.clear_objects()
 
     def wait_task(self, task_id):
         try:
@@ -420,6 +426,11 @@ class AlgoliaIndex(object):
                 raise e
             else:
                 logger.warning('%s NOT WAIT: %s', self.model, e)
+
+    def delete(self):
+        self.__index.delete()
+        if self.__tmp_index:
+            self.__tmp_index.delete()
 
     def reindex_all(self, batch_size=1000):
         """
@@ -457,13 +468,13 @@ class AlgoliaIndex(object):
                     self.settings['slaves'] = []
                     logger.debug("REMOVE SLAVES FROM SETTINGS")
 
-                self.__tmp_index.wait_task(self.__tmp_index.set_settings(self.settings)['taskID'])
+                self.__tmp_index.set_settings(self.settings).wait()
                 logger.debug('APPLY SETTINGS ON %s_tmp', self.index_name)
             rules = []
             synonyms = []
-            for r in self.__index.iter_rules():
+            for r in self.__index.browse_rules():
                 rules.append(r)
-            for s in self.__index.iter_synonyms():
+            for s in self.__index.browse_synonyms():
                 synonyms.append(s)
             if len(rules):
                 logger.debug('Got rules for index %s: %s', self.index_name, rules)
@@ -472,7 +483,7 @@ class AlgoliaIndex(object):
                 logger.debug('Got synonyms for index %s: %s', self.index_name, rules)
                 should_keep_synonyms = True
 
-            self.__tmp_index.clear_index()
+            self.__tmp_index.clear_objects()
             logger.debug('CLEAR INDEX %s_tmp', self.index_name)
 
             counts = 0
@@ -499,8 +510,8 @@ class AlgoliaIndex(object):
                 logger.info('SAVE %d OBJECTS TO %s_tmp', len(batch),
                             self.index_name)
 
-            self.__client.move_index(self.__tmp_index.index_name,
-                                     self.__index.index_name)
+            self.__client.move_index(self.tmp_index_name,
+                                     self.index_name)
             logger.info('MOVE INDEX %s_tmp TO %s', self.index_name,
                         self.index_name)
 
@@ -514,12 +525,12 @@ class AlgoliaIndex(object):
                 if should_keep_replicas or should_keep_slaves:
                     self.__index.set_settings(self.settings)
                 if should_keep_rules:
-                    response = self.__index.batch_rules(rules, forward_to_replicas=True)
-                    self.__index.wait_task(response['taskID'])
+                    response = self.__index.save_rules(rules, {'forwardToReplicas': True})
+                    response.wait()
                     logger.info("Saved rules for index %s with response: {}".format(response), self.index_name)
                 if should_keep_synonyms:
-                    response = self.__index.batch_synonyms(synonyms, forward_to_replicas=True)
-                    self.__index.wait_task(response['taskID'])
+                    response = self.__index.save_synonyms(synonyms, {'forwardToReplicas': True})
+                    response.wait()
                     logger.info("Saved synonyms for index %s with response: {}".format(response), self.index_name)
             return counts
         except AlgoliaException as e:

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -66,7 +66,7 @@ class AlgoliaEngine(object):
         self.__registered_models[model] = index_obj
 
         if (isinstance(auto_indexing, bool) and
-            auto_indexing) or self.__auto_indexing:
+                auto_indexing) or self.__auto_indexing:
             # Connect to the signalling framework.
             post_save.connect(self.__post_save_receiver, model)
             pre_delete.connect(self.__pre_delete_receiver, model)

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -9,11 +9,12 @@ from algoliasearch.user_agent import UserAgent
 from .models import AlgoliaIndex
 from .settings import SETTINGS
 from .version import VERSION
-from algoliasearch.version import VERSION as CLIENT_VERSION
-from platform import python_version
 from django import get_version as django_version
 
 logger = logging.getLogger(__name__)
+
+UserAgent.add("Algolia for Django", VERSION)
+UserAgent.add("Django", django_version())
 
 
 class AlgoliaEngineError(Exception):
@@ -40,13 +41,6 @@ class AlgoliaEngine(object):
 
         self.__registered_models = {}
         self.client = SearchClient.create(app_id, api_key)
-        # UserAgent.add()
-        # self.client.set_extra_headers(
-        #     **{
-        #         "User-Agent": "Algolia for Python (%s); Python (%s); Algolia for Django (%s); Django (%s)"
-        #         % (CLIENT_VERSION, python_version(), VERSION, django_version)
-        #     }
-        # )
 
     def is_registered(self, model):
         """Checks whether the given models is registered with Algolia engine"""

--- a/algoliasearch_django/version.py
+++ b/algoliasearch_django/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.7.3'
+VERSION = '1.7.4'

--- a/algoliasearch_django/version.py
+++ b/algoliasearch_django/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.7.4'
+VERSION = '2.0.0'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     license='MIT License',
     packages=find_packages(exclude=['tests']),
-    install_requires=['django>=1.7', 'algoliasearch>=1.0,<2.0'],
+    install_requires=['django>=1.7', 'algoliasearch>=2.0,<3.0'],
     description='Algolia Search integration for Django',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,8 +13,11 @@ from .models import User
 class CommandsTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
-        algolia_engine.client.delete_index(get_adapter(User).index_name)
-        algolia_engine.client.delete_index(get_adapter(Website).index_name)
+        user_index_name = get_adapter(User).index_name
+        website_index_name = get_adapter(Website).index_name
+
+        algolia_engine.client.init_index(user_index_name).delete()
+        algolia_engine.client.init_index(website_index_name).delete()
 
     def setUp(self):
         # Create some records

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,12 @@
 import six
+import re
 
 from django.conf import settings
 from django.test import TestCase
 
+from algoliasearch.user_agent import UserAgent
+from django import get_version as django_version
+from algoliasearch_django.version import VERSION
 from algoliasearch_django import algolia_engine
 from algoliasearch_django import AlgoliaIndex
 from algoliasearch_django import AlgoliaEngine
@@ -28,6 +32,14 @@ class EngineTestCase(TestCase):
         with self.settings(ALGOLIA=algolia_settings):
             with self.assertRaises(AlgoliaEngineError):
                 AlgoliaEngine(settings=settings.ALGOLIA)
+
+    def test_user_agent(self):
+        user_agent = UserAgent.get()
+
+        parts = re.split('\s*;\s*', user_agent)
+
+        self.assertIn('Django (%s)' % django_version(), parts)
+        self.assertIn('Algolia for Django (%s)' % VERSION, parts)
 
     def test_auto_discover_indexes(self):
         """Test that the `index` module was auto-discovered and the models registered"""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -42,8 +42,8 @@ class IndexTestCase(TestCase):
         ]
 
     def tearDown(self):
-        if hasattr(self, 'index') and hasattr(self.index, 'index_name'):
-            self.client.delete_index(self.index.index_name)
+        if hasattr(self, 'index'):
+            self.index.delete()
 
     def test_default_index_name(self):
         self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
@@ -94,7 +94,7 @@ class IndexTestCase(TestCase):
         with self.settings(ALGOLIA=algolia_settings):
             self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
             self.assertEqual(
-                self.index._AlgoliaIndex__tmp_index.index_name,
+                self.index.tmp_index_name,
                 'Website_tmp'
             )
 
@@ -104,7 +104,7 @@ class IndexTestCase(TestCase):
         with self.settings(ALGOLIA=algolia_settings):
             self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
             self.assertEqual(
-                self.index._AlgoliaIndex__tmp_index.index_name,
+                self.index.tmp_index_name,
                 'prefix_Website_tmp'
             )
 
@@ -115,7 +115,7 @@ class IndexTestCase(TestCase):
         with self.settings(ALGOLIA=algolia_settings):
             self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
             self.assertEqual(
-                self.index._AlgoliaIndex__tmp_index.index_name,
+                self.index.tmp_index_name,
                 'Website_tmp_suffix'
             )
 
@@ -126,7 +126,7 @@ class IndexTestCase(TestCase):
         with self.settings(ALGOLIA=algolia_settings):
             self.index = AlgoliaIndex(Website, self.client, settings.ALGOLIA)
             self.assertEqual(
-                self.index._AlgoliaIndex__tmp_index.index_name,
+                self.index.tmp_index_name,
                 'prefix_Website_tmp_suffix'
             )
 
@@ -253,8 +253,8 @@ class IndexTestCase(TestCase):
                 }
             }
         }
-        res = underlying_index.save_rule(rule)
-        self.index.wait_task(res['taskID'])
+
+        underlying_index.save_rule(rule).wait()
 
         # When reindexing with no settings on the instance
         self.index = WebsiteIndex(Website, self.client, settings.ALGOLIA)
@@ -267,7 +267,7 @@ class IndexTestCase(TestCase):
             del copy["_metadata"]
             return copy
 
-        rules = [r for r in underlying_index.iter_rules()]
+        rules = [r for r in underlying_index.browse_rules()]
         rules = list(map(remove_metadata, rules))
         self.assertEqual(len(rules), 1, "There should only be one rule")
         self.assertIn(rule, rules, "The existing rule should be kept over reindex")
@@ -282,8 +282,7 @@ class IndexTestCase(TestCase):
 
         # Given some existing synonyms on the index
         synonym = {'objectID': 'street', 'type': 'altCorrection1', 'word': 'Street', 'corrections': ['St']}
-        task = underlying_index.batch_synonyms([synonym])
-        underlying_index.wait_task(task['taskID'])
+        underlying_index.save_synonyms([synonym]).wait()
 
         # When reindexing with no settings on the instance
         self.index = WebsiteIndex(Website, self.client, settings.ALGOLIA)
@@ -291,7 +290,7 @@ class IndexTestCase(TestCase):
         time.sleep(10)  # FIXME: Refactor reindex_all to return taskID
 
         # Expect the synonyms to be kept across reindex
-        synonyms = [s for s in underlying_index.iter_synonyms()]
+        synonyms = [s for s in underlying_index.browse_synonyms()]
         self.assertEqual(len(synonyms), 1, "There should only be one synonym")
         self.assertIn(synonym, synonyms, "The existing synonym should be kept over reindex")
 
@@ -661,7 +660,7 @@ class IndexTestCase(TestCase):
         self.user.bio = "крупнейших"
         self.user.save()
         self.index = CyrillicIndex(User, self.client, settings.ALGOLIA)
-        self.index.wait_task(self.index.save_record(self.user)["taskID"])
+        self.index.save_record(self.user).wait()
         result = self.index.raw_search("крупнейших")
         self.assertEqual(result['nbHits'], 1, "Search should return one result")
         self.assertEqual(result['hits'][0]['name'], 'Algolia', "The result should be self.user")

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -17,7 +17,7 @@ class SignalTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        algolia_engine.client.delete_index(get_adapter(Website).index_name)
+        get_adapter(Website).delete()
 
     def tearDown(self):
         clear_index(Website)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes   
| BC breaks?        | yes     
| Related Issue     | Fix https://github.com/algolia/algoliasearch-django/issues/298 https://github.com/algolia/algoliasearch-django/issues/308
| Need Doc update   | yes


## Describe your change

This updates the python client used to the latest major (>= 2.0).
It migrates all the methods following the [upgrade guide](https://www.algolia.com/doc/api-client/getting-started/upgrade-guides/python/).

:warning:  Release this under a new major 2.0: the extension exposes many client objects that now have changed, and users of 1.x might be relying on them (eg. `AlgoliaEngine.client` is no longer the same object)    

## What problem is this fixing?

It's not easy to use two different versions of the same library in python.
Using the Django integration got you stuck with the older version of the client. 
