### PR TITLE
Update algoliasearch requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     license='MIT License',
     packages=find_packages(exclude=['tests']),
-    install_requires=['django>=1.7', 'algoliasearch>=1.0,<2.0'],
+    install_requires=['django>=1.7', 'algoliasearch>=2.0,<3.0'],
     description='Algolia Search integration for Django',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

`algoliasearch` has been updated to 2.0 in requirements.txt but that file is not used in setup.py.
I have updated the dependency version in setup.py as well.

## What problem is this fixing?
At the moment, installing `algoliasearch>=2.0` with the latest `algoliasearch_django` doesn't work because of the setup.py dependency.
