### PR TITLE
Fix syntax warning for literal check with is

### DIFF
--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -260,7 +260,7 @@ class AlgoliaIndex(object):
                 # noinspection PyDeprecation
                 count_args = len(inspect.getargspec(self.should_index).args)
 
-            if is_method or count_args is 1:
+            if is_method or count_args == 1:
                 # bound method, call with instance
                 return self.should_index(instance)
             else:


### PR DESCRIPTION
"is" used with a literal, use equality tests instead.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

"is" used with a number, use equality tests instead.

## What problem is this fixing?

See Python 3.8 release notes:

"The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. "
