### PR TITLE
build: Add django 3.2 tests with python 3.6 and python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,17 @@ matrix:
   - python: 3.6
     env: TOXENV=py36-django22LTS
   - python: 3.6
-    env: TOXENV=py36-django31
+    env: TOXENV=py36-django30
   - python: 3.6
     env: TOXENV=py36-django31
+  - python: 3.6
+    env: TOXENV=py36-django32
+  - python: 3.8
+    env: TOXENV=py38-django30
+  - python: 3.8
+    env: TOXENV=py38-django31
+  - python: 3.8
+    env: TOXENV=py38-django32
     script:
       - docker build -t algoliasearch_django .
       - docker run -it --rm --env ALGOLIA_APPLICATION_ID --env ALGOLIA_API_KEY --env ALGOLIA_SEARCH_API_KEY --env TOXENV -v $PWD:/code -w /code algoliasearch_django tox

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -260,7 +260,7 @@ class AlgoliaIndex(object):
                 # noinspection PyDeprecation
                 count_args = len(inspect.getargspec(self.should_index).args)
 
-            if is_method or count_args is 1:
+            if is_method or count_args == 1:
                 # bound method, call with instance
                 return self.should_index(instance)
             else:

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,9 @@ envlist =
     {py34,py35,py36}-django20
     {py34,py35,py36}-django21
     {py34,py35,py36}-django22LTS
-    {py34,py35,py36}-django30
-    {py34,py35,py36}-django31
+    {py34,py35,py36,py38}-django30
+    {py34,py35,py36,py38}-django31
+    {py36,py38}-django32
     coverage
 skip_missing_interpreters = True
 
@@ -29,6 +30,7 @@ deps =
     django22LTS: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 passenv =
     ALGOLIA*
     TRAVIS*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | None  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change
- Added tests support for `Python3.8` and `Django3.2`.
<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?
- [edX/course-discovery](https://github.com/edx/course-discovery/) Django3.2 upgrade needs test support for Django32 in this package.
<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
