### PR TITLE
feat: add support for Python 3.9, 3.10 and 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.7
-algoliasearch>=2.0,<3.0
+algoliasearch>=3.0,<4.0
 # dev dependencies
 pypandoc
 wheel

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     license='MIT License',
     packages=find_packages(exclude=['tests']),
-    install_requires=['django>=1.7', 'algoliasearch>=2.0,<3.0'],
+    install_requires=['django>=1.7', 'algoliasearch>=3.0,<4.0'],
     description='Algolia Search integration for Django',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 path_readme = os.path.join(os.path.dirname(__file__), 'README.md')
 try:
     import pypandoc
-    README = pypandoc.convert(path_readme, 'rst')
+    README = pypandoc.convert_file(path_readme, 'rst')
 except (IOError, ImportError):
     with open(path_readme) as readme:
         README = readme.read()

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,12 @@ envlist =
     {py34,py35,py36}-django20
     {py34,py35,py36}-django21
     {py34,py35,py36}-django22LTS
-    {py34,py35,py36,py38}-django30
-    {py34,py35,py36,py38}-django31
-    {py36,py38}-django32
+    {py36,py37,py38,py39}-django30
+    {py36,py37,py38,py39}-django31
+    {py36,py37,py38,py39,py310}-django32
+    {py38,py39,py310}-django40
+    {py38,py39,py310,py311}-django41
+    {py38,py39,py310,py311}-django42
     coverage
 skip_missing_interpreters = True
 
@@ -31,6 +34,9 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
 passenv =
     ALGOLIA*
     TRAVIS*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #328 
| Need Doc update   | yes


## Describe your change

Algolia Search python client](https://pypi.org/project/algoliasearch/) recently released a version to support python 3.11 (algoliasearch 3.0.0). However, this algoliasearch-django requires algoliasearch<3.0 and >=2.0

## What problem is this fixing?
Requirement constraint that needs updating for Python 3.11 compatibility.

