### PR TITLE
fix: remove highlightResult from response

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -14,12 +14,12 @@ def main():
     TestRunner = get_runner(settings)
     test_runner = TestRunner(failfast=True)
     # kept here to run a single test
-    # failures = test_runner.run_tests(
-    #     [
-    #         "tests.test_index.IndexTestCase.test_reindex_with_rules"
-    #     ]
-    # )
-    failures = test_runner.run_tests(["tests"])
+    failures = test_runner.run_tests(
+        [
+            "tests.test_index.IndexTestCase"
+        ]
+    )
+    # failures = test_runner.run_tests(["tests"])
     sys.exit(bool(failures))
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -14,12 +14,12 @@ def main():
     TestRunner = get_runner(settings)
     test_runner = TestRunner(failfast=True)
     # kept here to run a single test
-    failures = test_runner.run_tests(
-        [
-            "tests.test_index.IndexTestCase"
-        ]
-    )
-    # failures = test_runner.run_tests(["tests"])
+    # failures = test_runner.run_tests(
+    #     [
+    #         "tests.test_index.IndexTestCase"
+    #     ]
+    # )
+    failures = test_runner.run_tests(["tests"])
     sys.exit(bool(failures))
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,6 +10,12 @@ from algoliasearch_django.models import AlgoliaIndexError
 from .models import User, Website, Example
 
 
+def sanitize(hit):
+    if "_highlightResult" in hit:
+        hit.pop("_highlightResult")
+    return hit
+
+
 class IndexTestCase(TestCase):
     def setUp(self):
         self.client = algolia_engine.client
@@ -320,7 +326,7 @@ class IndexTestCase(TestCase):
         synonyms = []
         self.client.browse_synonyms(
             self.index.index_name,
-            lambda _resp: synonyms.extend([_hit.to_dict() for _hit in _resp.hits]),
+            lambda _resp: synonyms.extend([sanitize(_hit.to_dict()) for _hit in _resp.hits]),
         )
         self.assertEqual(len(synonyms), 1, "There should only be one synonym")
         self.assertIn(


### PR DESCRIPTION
## 🧭 What and Why

🎟 Related Issue:

### Changes included:

there is a regression in the new api clients, we don't remove the `highlightResult` anymore of the returned objects from the browse response.

in the meantime of a fix there, we can fix it in the integration to prevent different behaviors, as the API doesn't allow saving rules with `highlightResult`